### PR TITLE
REP-25: Replace Unicode emoji icons with Lucide React icons

### DIFF
--- a/components/workout/WorkoutControls.tsx
+++ b/components/workout/WorkoutControls.tsx
@@ -3,6 +3,7 @@ import Button from '../ui/Button';
 import { WorkoutSet } from '../../hooks/useWorkout';
 import { motion } from 'framer-motion';
 import ConfirmationModal from '../ui/ConfirmationModal';
+import { Play, Pause, RotateCcw, Check, MoreHorizontal } from 'lucide-react';
 
 interface WorkoutControlsProps {
   isRunning: boolean;
@@ -64,9 +65,7 @@ export default function WorkoutControls({
             onClick={isRunning ? onPause : onStart}
             className="w-16 flex justify-center items-center"
           >
-            <span className="text-2xl">
-              {isRunning ? '⏸' : '▶'}
-            </span>
+            {isRunning ? <Pause size={24} /> : <Play size={24} />}
           </Button>
         </motion.div>
         
@@ -80,7 +79,7 @@ export default function WorkoutControls({
             size="lg"
             onClick={handleResetClick}
           >
-            <span className="text-2xl">⟲</span>
+            <RotateCcw size={24} />
           </Button>
         </motion.div>
         
@@ -95,9 +94,7 @@ export default function WorkoutControls({
             onClick={handleSaveClick}
             disabled={isSaving || isRunning || workoutSets.length === 0}
           >
-            <span className="text-2xl">
-              {isSaving ? '⋯' : '✓'}
-            </span>
+            {isSaving ? <MoreHorizontal size={24} /> : <Check size={24} />}
           </Button>
         </motion.div>
       </div>

--- a/components/workout/WorkoutNavigation.tsx
+++ b/components/workout/WorkoutNavigation.tsx
@@ -1,4 +1,5 @@
 import Button from '../ui/Button';
+import { BarChart3, VolumeX, Volume2 } from 'lucide-react';
 
 // Temporary User type until MCP integration is complete
 interface User {
@@ -37,7 +38,7 @@ export default function WorkoutNavigation({
                 className="bg-purple-600 hover:bg-purple-700"
               >
                 <span className="hidden sm:inline">History</span>
-                <span className="sm:hidden">📊</span>
+                <span className="sm:hidden"><BarChart3 size={16} /></span>
               </Button>
               
               <Button
@@ -45,7 +46,7 @@ export default function WorkoutNavigation({
                 size="sm"
                 onClick={onToggleAudio}
               >
-                {isAudioMuted ? '🔇' : '🔊'}
+                {isAudioMuted ? <VolumeX size={16} /> : <Volume2 size={16} />}
               </Button>
               
               <Button

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@supabase/supabase-js": "^2.50.3",
         "dotenv": "^17.0.1",
         "framer-motion": "^12.23.1",
+        "lucide-react": "^0.525.0",
         "next": "15.3.5",
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
@@ -1491,6 +1492,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.525.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.525.0.tgz",
+      "integrity": "sha512-Tm1txJ2OkymCGkvwoHt33Y2JpN5xucVq1slHcgE6Lk0WjDfjgKWor5CdVER8U6DvcfMwh4M8XxmpTiyzfmfDYQ==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/magic-string": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@supabase/supabase-js": "^2.50.3",
     "dotenv": "^17.0.1",
     "framer-motion": "^12.23.1",
+    "lucide-react": "^0.525.0",
     "next": "15.3.5",
     "react": "^19.0.0",
     "react-dom": "^19.0.0"


### PR DESCRIPTION
## Summary
- Replace Unicode emoji icons with Lucide React SVG icons for consistent cross-platform rendering
- Fix mobile icon rendering inconsistencies between iOS/Android and desktop browsers
- Install lucide-react library for professional, scalable icons

## Changes Made
**Bottom Navigation Icons (WorkoutControls.tsx):**
- Play/Pause: ▶/⏸ → `<Play>` / `<Pause>`
- Reset: ⟲ → `<RotateCcw>` 
- Save: ✓/⋯ → `<Check>` / `<MoreHorizontal>`

**Top Navigation Icons (WorkoutNavigation.tsx):**
- History: 📊 → `<BarChart3>` 
- Audio: 🔇/🔊 → `<VolumeX>` / `<Volume2>`

## Problem Solved
Unicode emoji characters render differently across platforms:
- Desktop browsers use system fonts
- Mobile browsers may use different emoji fonts or fallback symbols
- Inconsistent appearance between iOS, Android, and desktop

## Solution Benefits
- **Consistent rendering**: SVG icons look identical on all platforms
- **Professional appearance**: Clean, purpose-built UI icons
- **Better accessibility**: Proper icon sizing and contrast
- **Scalable**: Works at any size without pixelation

## Test Plan
- [x] Icons render correctly on development server
- [x] All icon sizes are consistent (16px for nav, 24px for controls)
- [x] Icons maintain proper accessibility and color contrast
- [ ] Test on mobile devices to confirm consistent rendering

This completes the REP-25 framer-motion and UI improvements ticket with consistent iconography across all platforms.